### PR TITLE
Add command to access wp-config file relative to currently viewed file

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,6 +8,10 @@
         "command": "wordpress_open_config"
     },
     {
+        "caption": "WordPress: Open Config File for Parent WP Install",
+        "command": "wordpress_open_parent_config"
+    },
+    {
         "caption": "WordPress: Toggle Debug",
         "command": "wordpress_debug_toggle"
     },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -20,6 +20,10 @@
                         "command": "wordpress_open_config"
                     },
                     {
+                        "caption": "Open Config File for Parent WP Install",
+                        "command": "wordpress_open_parent_config"
+                    },
+                    {
                         "caption": "Wordpress Doc Lookup",
                         "command": "wordpressdoc"
                     },

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Sublime Text WordPress Dev Plugin #
 
-Simple plugin for [Sublime Text](http://www.sublimetext.com/ "Sublime Text") which adds a few commands that may be handy for people building sites with wordpress.
+Simple plugin for [Sublime Text](http://www.sublimetext.com/ "Sublime Text") which adds a few commands that may be handy for people building sites with WordPress.
 
 ## Install ##
 Take the easy route and use [Package Control](http://wbond.net/sublime_packages/package_control).  If you're not already using it, you want to jump on that band wagon!
 
 If you're hardcore or want to hack away on this plugin, clone this repo or download it.  Then simply move the *WordPressDev* folder into your Sublime Text plugins directory.
 
-Once you've donwloaded it or got it via Package Control, you want to tell it the location of your `wp-config.php` file.  To do this, go to the  _Preferences -> Package Settings -> WordPressDev_ menu and edit your *User* settings.  In that file add the following:
+Once you've downloaded it or got it via Package Control, you want to tell it the location of your `wp-config.php` file.  To do this, go to the  _Preferences -> Package Settings -> WordPressDev_ menu and edit your *User* settings.  In that file add the following:
 ``` json
 {
     //Path to where your wp-config.php file resides
@@ -17,17 +17,26 @@ Once you've donwloaded it or got it via Package Control, you want to tell it the
 
 Make sure to change `"wp_config_file"` to the full path to your `wp-config.php` file!
 
+_You can also now access your `wp-config.php` without setting anything in Sublime Text. See below._
+
 ## Commands ##
 Commands listed here can be found in the command pallet prefixed with ```WordPress: ``` or they can be accessed from the _Tools ->  WordPress_ menu
 
 ### Open Config File ###
-Allows you to quickly view/edit your wordpress config file. Default shortcut is ```ctrl+alt+o```
+Allows you to quickly view/edit your WordPress config file. Default shortcut is ```ctrl+alt+o```
+
+### Open Config File for Parent WP Install ###
+
+Allows you to open the config file in the relative root of your WordPress install.
+
+No default shortcut. You can access this command through the _Tools ->  WordPress_ menu or using the command palette
+
 
 ### Toggle Debug ###
 Allows you to quickly toggle the ```WP_DEBUG``` variable.
 
 ### Switch Database ###
-If you like to keep seperate databases for each site you build you can build up a list like this in your wp-config file:
+If you like to keep separate databases for each site you build you can build up a list like this in your wp-config file:
 
 ``` php
 //define('DB_NAME', 'wp_bootstrap_theme'); //bootstrap test
@@ -52,10 +61,10 @@ wp_rgt - Responsive grid test
 
 The default shortcut for this command is ```ctrl+alt+w```
 
-### Wordpress Doc Lookup ###
-Opens up the wordpress codex reference seraching for the highlighted text
+### WordPress Doc Lookup ###
+Opens up the WordPress codex reference seraching for the highlighted text
 The default shortcut for this command is ```ctrl+m, ctrl+w```
 
 ### PHP Doc Lookup ###
-Opens up the php docs seraching for the highlighted text
+Opens up the PHP docs searching for the highlighted text
 The default shortcut for this command is ```ctrl+m, ctrl+p```

--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,1 +1,5 @@
-{"description": "Some helpful additions to Sublime Text if you do a lot of wordpress sites: PHP/WordPress Function reference lookups, Swith DBs, Toggle Debug and quickly access your config file", "version": "2015.01.22.16.04.50", "url": "https://github.com/huntlyc/Sublime-Wordpress-Dev-Plugin"}
+{
+  "description": "Some helpful additions to Sublime Text if you do a lot of wordpress sites: PHP/WordPress Function reference lookups, Switch DBs, Toggle Debug and quickly access your config file",
+  "version": "2015.12.26",
+  "url": "https://github.com/huntlyc/Sublime-Wordpress-Dev-Plugin"
+}

--- a/wordpress_dev.py
+++ b/wordpress_dev.py
@@ -40,6 +40,37 @@ class WordpressOpenConfigCommand(sublime_plugin.WindowCommand):
             sublime.status_message("wp-config file doesn't exist, " +
                                    'check your settings')
 
+class WordpressOpenParentConfigCommand(sublime_plugin.TextCommand):
+  
+  # Set by is_enabled()
+  base_name = ''
+  path_parts = []
+
+  def run(self, edit):
+    self.base_name = self.view.file_name()
+    self.path_parts = self.base_name.split('/')
+    
+    self.path_base = self.path_parts
+    self.path_base.pop()
+    self.path_base = '/'.join( self.path_base )
+
+    if len(self.base_name) > 0:
+
+      string_loc = self.base_name.find('wp-content')
+
+      # sublime.error_message( 'path base : ' + self.path_base ) 
+      if ( string_loc > 0 ):
+
+        wp_install_base = self.base_name[0:string_loc]
+        self.view.window().open_file( wp_install_base + 'wp-config.php')
+      # elif ( True ):
+        # Check if the wp-config file is in the current folder
+        # in_curr_folder = self.view.window().open_file( self.path_base + '/wp-config.php') 
+      else:
+        sublime.error_message( 'You must run this command while viewing a file inside a WordPress install in the /wp-content folder or deeper.' ) 
+
+    return False
+
 
 class WordpressDbSwitcherCommand(sublime_plugin.WindowCommand):
     def run(self, extensions=[]):


### PR DESCRIPTION
I was going to release this as a standalone package but I thought it would feather in nicely with your existing feature set.

The way this command works is just searching up the dir tree until it finds the WP root folder and opens the wp-config.php found there. Really useful when editing themes or plugins.

Happy to reconsider the name of the command, descriptions, key binding etc. This is pretty much my first stab at writing a package so I'm down to modify it if need be.

Thanks!
Eli
